### PR TITLE
Upgrading the version of laravel/socialite

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "kneipp/socialite-wrapper",
+    "name": "nestednet/socialite-wrapper",
     "description": "Laravel socialite wrapper.",
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "laravel/socialite": "^3.0"
+        "laravel/socialite": "^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
In order to use laravel 6.0 the laravel/socialite version should be >= 4.0